### PR TITLE
Fix mdx chunk operator

### DIFF
--- a/airflow_provider_tm1/utils/mdx_alchemy/__init__.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/__init__.py
@@ -26,4 +26,4 @@ def mdx_to_mdx_builder(mdx: str) -> MdxBuilder:
     """
     parser = build_parser()
     mdx_tree = parser.parse(mdx)
-    return MDXTransformer().transform(mdx_tree)
+    return MDXTransformer().transform(mdx_tree).children[0]

--- a/airflow_provider_tm1/utils/mdx_alchemy/__init__.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/__init__.py
@@ -26,4 +26,7 @@ def mdx_to_mdx_builder(mdx: str) -> MdxBuilder:
     """
     parser = build_parser()
     mdx_tree = parser.parse(mdx)
-    return MDXTransformer().transform(mdx_tree).children[0]
+    transformed = MDXTransformer().transform(mdx_tree)
+    if not transformed.children:
+        raise ValueError("Transformation resulted in an empty children list.")
+    return transformed.children[0]

--- a/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
@@ -65,28 +65,28 @@ def chunk_query(tm1: TM1Service, mdx: str|MdxBuilder, chunk_size: int = 1000) ->
     # row axis 
     row_set = {}
     for row_dim_set in mdx_builder.axes.get(1, MdxAxis.empty()).dim_sets:
-        elements = tm1.elements.execute_set_mdx_element_names(row_dim_set.expression)
+        elements = tm1.elements.execute_set_mdx_element_names(row_dim_set.to_mdx())
         subset = AnonymousSubset(
-            row_dim_set.dimension_name, 
-            row_dim_set.hierarchy_name,
+            row_dim_set.dimension, 
+            row_dim_set.hierarchy,
             elements=elements
         )
-        __mdx_builder_stat.update({row_dim_set.dimension_name: len(elements)})
-        row_set.update({row_dim_set.dimension_name: subset})
-        
+        __mdx_builder_stat.update({row_dim_set.dimension: len(elements)})
+        row_set.update({row_dim_set.dimension: subset})
+
     # column axis 
     col_set = {}
     for col_dim_set in mdx_builder.axes.get(0, MdxAxis.empty()).dim_sets:
         element_names = tm1.elements.execute_set_mdx_element_names(col_dim_set.to_mdx())
         subset = AnonymousSubset(
-            col_dim_set.dimension_name, 
-            col_dim_set.hierarchy_name,
+            col_dim_set.dimension, 
+            col_dim_set.hierarchy,
             elements=element_names
         )
-        __mdx_builder_stat.update({col_dim_set.dimension_name: len(element_names)})
+        __mdx_builder_stat.update({col_dim_set.dimension: len(element_names)})
 
-        col_set.update({col_dim_set.dimension_name: subset})
-        
+        col_set.update({col_dim_set.dimension: subset})
+
     title_set = {}
     for title in mdx_builder._where.members:
         subset = AnonymousSubset(

--- a/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
@@ -65,6 +65,7 @@ def chunk_query(tm1: TM1Service, mdx: str|MdxBuilder, chunk_size: int = 1000) ->
     # row axis 
     row_set = {}
     for row_dim_set in mdx_builder.axes.get(1, MdxAxis.empty()).dim_sets:
+        # Using to_mdx() for consistency with the column axis implementation.
         elements = tm1.elements.execute_set_mdx_element_names(row_dim_set.to_mdx())
         subset = AnonymousSubset(
             row_dim_set.dimension, 

--- a/airflow_provider_tm1/utils/mdx_alchemy/transformer.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/transformer.py
@@ -238,6 +238,8 @@ class MDXTransformer(lark.Transformer):
 
     def elements_hierarchy_set(self, item):
         hierarchy_set = ElementsHierarchySet(*[i for i in item if isinstance(i, Member)])
+        if not hierarchy_set.members:
+            raise ValueError("The members list in hierarchy_set is empty. Cannot access the first member.")
         hierarchy_set.dimension = hierarchy_set.members[0].dimension
         hierarchy_set.hierarchy = hierarchy_set.members[0].hierarchy
         return hierarchy_set

--- a/airflow_provider_tm1/utils/mdx_alchemy/transformer.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/transformer.py
@@ -237,5 +237,7 @@ class MDXTransformer(lark.Transformer):
         return DescendantsHierarchySet(member=item[1],)
 
     def elements_hierarchy_set(self, item):
-        return ElementsHierarchySet(*[i for i in item if isinstance(i, Member)])
-    
+        hierarchy_set = ElementsHierarchySet(*[i for i in item if isinstance(i, Member)])
+        hierarchy_set.dimension = hierarchy_set.members[0].dimension
+        hierarchy_set.hierarchy = hierarchy_set.members[0].hierarchy
+        return hierarchy_set


### PR DESCRIPTION
This pull request introduces several updates to improve the handling of MDX transformations and queries in the `airflow_provider_tm1` package. The changes focus on refining the transformation logic, improving MDX query chunking, and enhancing hierarchy set handling.

### Improvements to MDX transformation and parsing:
* Updated the `mdx_to_mdx_builder` function in `airflow_provider_tm1/utils/mdx_alchemy/__init__.py` to return the first child of the transformed MDX tree, ensuring consistent output for downstream processing.

### Enhancements to MDX query chunking:
* Modified the `chunk_query` function in `airflow_provider_tm1/utils/mdx_alchemy/optimizer.py` to use `to_mdx()` for generating MDX expressions from dimension sets. Additionally, replaced `dimension_name` and `hierarchy_name` with `dimension` and `hierarchy` attributes for better consistency and clarity.

### Refinements to hierarchy set handling:
* Enhanced the `elements_hierarchy_set` method in `airflow_provider_tm1/utils/mdx_alchemy/transformer.py` to explicitly set the `dimension` and `hierarchy` attributes based on the first member of the hierarchy set, improving data integrity and usability.