### PR TITLE
Feat mdx chunk operator

### DIFF
--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -45,6 +45,12 @@ class TM1MDXChunkOperator(BaseOperator):
                 result = chunk_query(tm1, self.mdx, self.chunk_size)
                 self.log.info("MDX query executed successfully in chunks.")
                 return result
+            except ValueError as e:
+                self.log.error("ValueError while executing MDX query in chunks: %s", e)
+                raise AirflowException(f"ValueError occurred during MDX query execution: {e}")
+            except ConnectionError as e:
+                self.log.error("ConnectionError while executing MDX query in chunks: %s", e)
+                raise AirflowException(f"ConnectionError occurred during MDX query execution: {e}")
             except Exception as e:
-                self.log.error("Error executing MDX query in chunks: %s", e)
-                raise AirflowException(f"Failed to execute MDX query in chunks: {e}")
+                self.log.error("Unexpected error while executing MDX query in chunks: %s", e)
+                raise AirflowException(f"Unexpected error occurred during MDX query execution: {e}")

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -40,7 +40,7 @@ class TM1MDXChunkOperator(BaseOperator):
         hook = TM1Hook(tm1_conn_id=self.tm1_conn_id)
         if self.skip_chunk_process:
             self.log.info("Skipping chunk processing. Returning MDX query.")
-            return [mdx_to_mdx_builder(self.mdx).to_mdx()]
+            return [self.mdx]
         with hook.get_conn() as tm1:
             try:
                 result = chunk_query(tm1, self.mdx, self.chunk_size)

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -19,9 +19,7 @@ class TM1MDXChunkOperator(BaseOperator):
     :param skip_chunk_process: If True, skips processing of chunks and only returns the MDX query.
     """
     
-    hook_name = 'tm1'
     default_conn_name = 'tm1_default'
-    conn_type = 'tm1'
     ui_color = '#BDDDEF'
     ui_fgcolor = '#434b53'
     
@@ -39,6 +37,13 @@ class TM1MDXChunkOperator(BaseOperator):
         self.tm1_conn_id = tm1_conn_id
         self.skip_chunk_process = skip_chunk_process
     
-    def execute(self, context: Context) -> None: 
-        ...
-    ...
+    def execute(self, context: Context): 
+        from airflow_provider_tm1.utils.mdx_alchemy.optimizer import chunk_query
+        from airflow_provider_tm1.utils.mdx_alchemy import mdx_to_mdx_builder
+        hook = TM1Hook(tm1_conn_id=self.tm1_conn_id)
+        if self.skip_chunk_process:
+            self.log.info("Skipping chunk processing. Returning MDX query.")
+            return [mdx_to_mdx_builder(self.mdx).to_mdx()]
+        with hook.get_conn() as tm1:
+            return chunk_query(tm1, self.mdx, self.chunk_size)
+

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -23,6 +23,8 @@ class TM1MDXChunkOperator(BaseOperator):
     hook_name = 'tm1'
     default_conn_name = 'tm1_default'
     conn_type = 'tm1'
+    ui_color = '#BDDDEF'
+    ui_fgcolor = '#434b53'
     
     @apply_defaults
     def __init__(

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -1,11 +1,8 @@
-from typing import Any, Callable, Collection, Mapping, Sequence
+from typing import Any
 
-import pandas as pd
-from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.sdk.definitions.context import Context
-from airflow.utils.operator_helpers import KeywordParameters
-from airflow.utils.context import context_merge
+from airflow.exceptions import AirflowException
 
 from airflow_provider_tm1.hooks.tm1 import TM1Hook
 
@@ -45,5 +42,10 @@ class TM1MDXChunkOperator(BaseOperator):
             self.log.info("Skipping chunk processing. Returning MDX query.")
             return [mdx_to_mdx_builder(self.mdx).to_mdx()]
         with hook.get_conn() as tm1:
-            return chunk_query(tm1, self.mdx, self.chunk_size)
-
+            try:
+                return chunk_query(tm1, self.mdx, self.chunk_size)
+            except Exception as e:
+                self.log.error("Error executing MDX query in chunks: %s", e)
+                raise AirflowException(f"Failed to execute MDX query in chunks: {e}")
+            finally:
+                self.log.info("MDX query executed successfully in chunks.")

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -43,9 +43,9 @@ class TM1MDXChunkOperator(BaseOperator):
             return [mdx_to_mdx_builder(self.mdx).to_mdx()]
         with hook.get_conn() as tm1:
             try:
-                return chunk_query(tm1, self.mdx, self.chunk_size)
+                result = chunk_query(tm1, self.mdx, self.chunk_size)
+                self.log.info("MDX query executed successfully in chunks.")
+                return result
             except Exception as e:
                 self.log.error("Error executing MDX query in chunks: %s", e)
                 raise AirflowException(f"Failed to execute MDX query in chunks: {e}")
-            finally:
-                self.log.info("MDX query executed successfully in chunks.")

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -1,0 +1,44 @@
+from typing import Any, Callable, Collection, Mapping, Sequence
+
+import pandas as pd
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.sdk.definitions.context import Context
+from airflow.utils.decorators import apply_defaults
+from airflow.utils.operator_helpers import KeywordParameters
+from airflow.utils.context import context_merge
+
+from airflow_provider_tm1.hooks.tm1 import TM1Hook
+
+class TM1MDXChunkOperator(BaseOperator):
+    """
+    This operator executes an MDX query in chunks.
+
+    :param mdx: Valid MDX Query
+    :param chunk_size: Size of each chunk to be processed
+    :param tm1_conn_id: The Airflow connection used for TM1 credentials.
+    :param skip_chunk_process: If True, skips processing of chunks and only returns the MDX query.
+    """
+    
+    hook_name = 'tm1'
+    default_conn_name = 'tm1_default'
+    conn_type = 'tm1'
+    
+    @apply_defaults
+    def __init__(
+        self,
+        mdx: str,
+        chunk_size: int = 1000,
+        tm1_conn_id: str = default_conn_name,
+        skip_chunk_process: bool = False,
+        **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self.mdx = mdx
+        self.chunk_size = chunk_size
+        self.tm1_conn_id = tm1_conn_id
+        self.skip_chunk_process = skip_chunk_process
+    
+    def execute(self, context: Context) -> None: 
+        ...
+    ...

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -4,7 +4,6 @@ import pandas as pd
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.sdk.definitions.context import Context
-from airflow.utils.decorators import apply_defaults
 from airflow.utils.operator_helpers import KeywordParameters
 from airflow.utils.context import context_merge
 
@@ -26,7 +25,6 @@ class TM1MDXChunkOperator(BaseOperator):
     ui_color = '#BDDDEF'
     ui_fgcolor = '#434b53'
     
-    @apply_defaults
     def __init__(
         self,
         mdx: str,

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -36,7 +36,6 @@ class TM1MDXChunkOperator(BaseOperator):
     
     def execute(self, context: Context): 
         from airflow_provider_tm1.utils.mdx_alchemy.optimizer import chunk_query
-        from airflow_provider_tm1.utils.mdx_alchemy import mdx_to_mdx_builder
         hook = TM1Hook(tm1_conn_id=self.tm1_conn_id)
         if self.skip_chunk_process:
             self.log.info("Skipping chunk processing. Returning MDX query.")

--- a/airflow_provider_tm1/operators/tm1_mdx_chunk.py
+++ b/airflow_provider_tm1/operators/tm1_mdx_chunk.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from airflow.models import BaseOperator
+from airflow.sdk.bases.operator import BaseOperator
 from airflow.sdk.definitions.context import Context
 from airflow.exceptions import AirflowException
 

--- a/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
+++ b/airflow_provider_tm1/utils/mdx_alchemy/optimizer.py
@@ -10,7 +10,7 @@ def build_mdx_statement(
     row_set: dict[str, AnonymousSubset],
     col_set: dict[str, AnonymousSubset],
     cube_name: str,
-):
+) -> str:
     """
     Builds an MDX statement from the provided title, row, and column sets.
 
@@ -36,9 +36,9 @@ def build_mdx_statement(
             ElementsHierarchySet(*[Member(col_subset.dimension_name, col_subset.hierarchy_name, e) for e in col_subset.elements])
         )
 
-    return mdx_builder
+    return mdx_builder.to_mdx()
 
-def chunk_query(tm1: TM1Service, mdx: str|MdxBuilder, chunk_size: int = 1000) -> list[MdxBuilder]:
+def chunk_query(tm1: TM1Service, mdx: str|MdxBuilder, chunk_size: int = 1000) -> list[str]:
     """
     #! This function is experimental and not fully implemented yet.
     #! It is intended to split the MDX query into smaller chunks based on the specified chunk size.


### PR DESCRIPTION
This pull request introduces a new operator for executing MDX queries in chunks and refines related utility functions. The key changes include adding the `TM1MDXChunkOperator`, updating the return types in utility functions, and improving MDX query handling.

### New Operator Addition:
* [`airflow_provider_tm1/operators/tm1_mdx_chunk.py`](diffhunk://#diff-062de796d41f77125bcba1e5c0115e276780d2f7891d19fbfc8a1c1b7d704e16R1-R51): Added `TM1MDXChunkOperator`, which executes MDX queries in chunks, with parameters for chunk size, connection ID, and an option to skip chunk processing. It leverages the `TM1Hook` for TM1 connections and includes error handling for query execution.

### Utility Function Updates:
* `airflow_provider_tm1/utils/mdx_alchemy/optimizer.py`:
  - Updated `build_mdx_statement` to return a string MDX query instead of an `MdxBuilder` object, improving compatibility with downstream processes. [[1]](diffhunk://#diff-ebcea43246e3a5ce7e053044983b5b9ed9fe385f0387b65b347a449f49f6b2bdL13-R13) [[2]](diffhunk://#diff-ebcea43246e3a5ce7e053044983b5b9ed9fe385f0387b65b347a449f49f6b2bdL39-R41)
  - Modified `chunk_query` to return a list of MDX query strings instead of `MdxBuilder` objects, aligning with the updated return type of `build_mdx_statement`.